### PR TITLE
refactor: Changes package name to @digital-uk prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hbbtv-typings",
+  "name": "@digital-uk/hbbtv-typings",
   "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hbbtv-typings",
+  "name": "@digital-uk/hbbtv-typings",
   "version": "1.5.2",
   "description": "Typings for HbbTV 1.5 (TS 102 796 V1.2.1)",
   "keywords": [
@@ -11,16 +11,19 @@
     "declaration"
   ],
   "private": false,
-  "author": "philippsimon",
+  "author": "Digital UK",
+  "contributors": [
+    "philippsimon"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/philippsimon/hbbtv-typings.git"
+    "url": "git+https://github.com/Digital-UK/hbbtv-typings.git"
   },
   "bugs": {
-    "url": "https://github.com/philippsimon/hbbtv-typings/issues"
+    "url": "https://github.com/Digital-UK/hbbtv-typings/issues"
   },
-  "homepage": "https://github.com/philippsimon/hbbtv-typings#readme",
+  "homepage": "https://github.com/Digital-UK/hbbtv-typings#readme",
   "scripts": {
     "postversion": "git push && git push --tags",
     "test": "npm run build && npm run tslint",


### PR DESCRIPTION
Updates `package.json` and `package-lock.json` to reflect move to Digital UK namespace.

This is the first in a chain of PRs that refactor and expand upon the source repo to support existing apps, ATVG and xFVP.
However the intention is that this will be used in fvp-utils and possibly re-exported from there. As such, it will underpin applications that are developed against a growing framework. For that reason I've added a few of reviewers to, if nothing else, flag up the work that's coming and provide some foresight.