### PR TITLE
refactor: Adds generic Collection interface and refactors collections…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@
 /// <reference path="./types/Channel.d.ts" />
 /// <reference path="./types/ChannelConfig.d.ts" />
 /// <reference path="./types/ChannelList.d.ts" />
+/// <reference path="./types/Collection.d.ts" />
 /// <reference path="./types/Configuration.d.ts" />
 /// <reference path="./types/KeyEvent.d.ts" />
 /// <reference path="./types/Keyset.d.ts" />
@@ -33,14 +34,14 @@
 
 /**
  * @see http://www.etsi.org/deliver/etsi_ts%5C102700_102799%5C102796%5C01.02.01_60%5Cts_102796v010201p.pdf
- * 
+ *
  * 1. Open IPTV Forum Release 1 specification, volume 5 (V1.2): "Declarative Application Environment".
  *    NOTE: Available at http://www.oipf.tv/specifications.
  *    http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDFb
  * 2. Open IPTV Forum Release 1 specification, volume 2 (V1.2): "Media Formats".
  *    NOTE: Available at http://www.oipf.tv/specifications.
  * 3. ETSI TS 102 809 (V1.1.1): "Digital Video Broadcasting (DVB); Signalling and carriage of interactive applications and services in Hybrid Broadcast/Broadband environments".
- * 4. Open IPTV Forum Release 1 specification, volume 4 (V1.2): "Protocols". 
+ * 4. Open IPTV Forum Release 1 specification, volume 4 (V1.2): "Protocols".
  *    NOTE: Available at http://www.oipf.tv/specifications.
  * 5. Open IPTV Forum Release 1 specification, volume 7 (V1.2): "Authentication, Content Protection and Service Protection".
  *    NOTE: Available at http://www.oipf.tv/specifications.

--- a/types/AVComponentCollection.d.ts
+++ b/types/AVComponentCollection.d.ts
@@ -1,17 +1,3 @@
 declare namespace OIPF {
-    export class AVComponentCollection {
-      /**
-       * The number of items in the collection.
-      */
-      public readonly length: number;
-  
-      /**
-       * Return the item at position index in the collection.
-       *
-       * @param index The index of the item to be returned
-       *
-       * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=211
-       */
-      item( index: number ): OIPF.AVComponent;
-    }
-  }
+    export type AVComponentCollection = OIPF.Collection<OIPF.AVComponent>;
+}

--- a/types/ApplicationCollection.d.ts
+++ b/types/ApplicationCollection.d.ts
@@ -1,27 +1,3 @@
 declare namespace OIPF {
-
-    /**
-     * The ApplicationCollection class represents a collection of Application objects. Next to the properties and
-     * methods defined below an ApplicationCollection object SHALL support the array notation to access the
-     * Application objects in this collection
-     * 
-     * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=59
-     */
-    export class ApplicationCollection {
-        /**
-         * The number of items in the collection.
-         */
-        public readonly length: number;
-
-        /**
-         * Return the item at position `index` in the collection, or `undefined` if no item is present
-         * at that position.
-         * 
-         * @param index The index of the application to be returned. 
-         * 
-         * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=59
-         */
-        item( index: number ): OIPF.Application | undefined;
-    }
-
+    export type ApplicationCollection = OIPF.Collection<OIPF.Application>
 }

--- a/types/Collection.d.ts
+++ b/types/Collection.d.ts
@@ -1,0 +1,6 @@
+declare namespace OIPF {
+    export interface Collection<T> {
+        readonly length: number;
+        item(index: number): T;
+    }
+}

--- a/types/StringCollection.d.ts
+++ b/types/StringCollection.d.ts
@@ -1,5 +1,3 @@
 declare namespace OIPF {
-    export class StringCollection {
-
-    }
+    export type StringCollection = OIPF.Collection<string>;
 }


### PR DESCRIPTION
The OIPF spec defines several collection classes, e.g. `StringCollection`, `AVComponentCollection` etc.
All of these are `typedef`s, i.e.aliases for an underlying, generic class. So `StringCollection` is an alias for `Collection<string>`.
The source repo is incomplete with collections and doesn't follow this structure.
This change adds the generic `Collection<T>` interface and refactors existing collection interfaces as an alias of this.