### PR TITLE
add: Refactors KeyEvent/Keyset and adds missing properties

### DIFF
--- a/types/KeyEvent.d.ts
+++ b/types/KeyEvent.d.ts
@@ -1,3 +1,6 @@
+interface Window {
+    KeyEvent: KeyEvent & KeyEventConstants;
+}
 /**
  * @see http://www.oipf.tv/docs/oipf-archive/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-V1_1-2009-10-08.pdf#page=256
  */
@@ -38,9 +41,11 @@ interface KeyEventInit extends EventModifierInit {
   repeat?: boolean;
 }
 
-declare var KeyEvent: {
-  prototype: KeyEvent;
-  new(typeArg: 'keydown' | 'keypress' | 'keyup', eventInitDict?: KeyEventInit): KeyEvent;
+declare class KeyEvent {
+  constructor(typeArg: 'keydown' | 'keypress' | 'keyup', eventInitDict?: KeyEventInit);
+}
+
+declare class KeyEventConstants {
 
   /**
    * @see http://www.oipf.tv/docs/oipf-archive/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-V1_1-2009-10-08.pdf#page=234
@@ -82,7 +87,6 @@ declare var KeyEvent: {
    * @see http://www.oipf.tv/docs/oipf-archive/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-V1_1-2009-10-08.pdf#page=234
    */
   readonly VK_9: number;
-
   /**
    * @see http://www.oipf.tv/docs/oipf-archive/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-V1_1-2009-10-08.pdf#page=234
    */
@@ -198,4 +202,4 @@ declare var KeyEvent: {
    * @see http://www.oipf.tv/docs/oipf-archive/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-V1_1-2009-10-08.pdf#page=235
    */
   readonly VK_MUTE: number;
-};
+}

--- a/types/Keyset.d.ts
+++ b/types/Keyset.d.ts
@@ -5,10 +5,10 @@ declare namespace OIPF {
      * defining this. Common key events are represented by constants defined in this class which are combined in a bit-wise
      * mask to identify a set of key events. Less common key events are not included in one of the defined constants and form
      * part of an array.
-     * 
+     *
      * The supported key events indicated through the capability mechanism in section 9.3 SHALL be the same as the
      * maximum set of key events available to the browser as indicated through this object
-     * 
+     *
      * The default set of key events available to broadcast-related applications shall be none. The default set of key events
      * available to broadcast-independent or service provider related applications which do not call `Keyset.setValue`
      * SHALL be all those indicated by the constants in this class which are supported by the OITF excluding those indicated
@@ -17,87 +17,87 @@ declare namespace OIPF {
      * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
      */
     export class Keyset {
-    
+
         /**
          * Used to identify the `VK_RED` key event.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly RED: number;
 
         /**
          * Used to identify the `VK_GREEN` key event.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly GREEN: number;
 
         /**
          * Used to identify the `VK_YELLOW` key event.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
 
         readonly YELLOW: number;
         /**
          * Used to identify the `VK_BLUE` key event.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly BLUE: number;
 
         /**
          * Used to identify the `VK_UP`, `VK_DOWN`, `VK_LEFT`, `VK_RIGHT`, `VK_ENTER` and `VK_BACK` key events.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly NAVIGATION: number;
 
         /**
          * Used to identify the `VK_PLAY`, `VK_PAUSE`, `VK_STOP`, `VK_NEXT`, `VK_PREV`, `VK_FAST_FWD`, `VK_REWIND`, `VK_PLAY_PAUSE` key events.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly VCR: number;
 
         /**
          * Used to identify the `VK_PAGE_UP` and `VK_PAGE_DOWN` key events.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly SCROLL: number;
 
         /**
          * Used to identify the `VK_INFO` key event.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly INFO: number;
 
         /**
          * Used to identify the number events, 0 to 9.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly NUMERIC: number;
 
         /**
          * Used to identify all alphabetic events.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly ALPHA: number;
 
         /**
          * Used to indicate key events not included in one of the other constants in this class.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         readonly OTHER: number;
 
         /**
-         * The value of the keyset which this DAE application will receive. 
-         * 
+         * The value of the keyset which this DAE application will receive.
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=60
          */
         public readonly value: number;
@@ -106,16 +106,16 @@ declare namespace OIPF {
          * If the `OTHER` bit in the `value` property is set then this indicates those key events which are available
          * to the browser which are not included in one of the constants defined in this class, If the OTHER bit in
          * the `value` property is not set then this property is meaningless.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=61
          */
         public readonly otherKeys: number[];
-        
+
         /**
          * In combination with `maximumOtherKeys`, this indicates the maximum set of key events which are
          * available to the browser. When a bit in this `maximumValue` has value 0, the corresponding key events
          * are never available to the browser.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=61
          */
         public readonly maximumValue: number;
@@ -126,33 +126,38 @@ declare namespace OIPF {
          * not included in one of the constants defined in this class, if they are not listed in this array then they are
          * never available to the browser. If the `OTHER` bit in the value property is not set then this property is
          * meaningless.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=61
          */
         public readonly maximumOtherKeys: number[];
-        
+
+        /**
+         * This is not strictly spec compliant but is defined by certain manufacturers whose devices offer pointer support.
+         */
+        public supportsPointer: boolean;
+
         /**
          * Sets the value of the keyset which this DAE application requests to receive. Where
          * more than one DAE application is running, the events delivered to the browser
          * SHALL be the union of the events requested by all running DAE applications. Under
          * these circumstances, applications may receive events which they have not
          * requested to receive.
-         * 
+         *
          * The return value indicates which keys will be delivered to this DAE application
          * encoded as bit-wise mask of the constants defined in this class
-         * 
+         *
          * @param value     The value is a number which is a bit-wise mask of the constants
          *                  defined in this class. For example;
          *                  ```
          *                  myKeyset = myApplication.privateData.keyset;
          *                  myKeyset.setValue(0x00000013);
          *                  myKeyset.setValue(myKeyset.INFO | myKeyset.NUMERIC);
-         *                  ``` 
+         *                  ```
          * @param otherKeys If the `value` parameter has the `OTHER`
          *                  bit set then it is used to indicate the key events that the application
          *                  wishes to receive which are not represented by constants defined in
          *                  this class.
-         * 
+         *
          * @see http://www.oipf.tv/docs/OIPF-T1-R1-Specification-Volume-5-Declarative-Application-Environment-v1_2-2012-09-19.PDF#page=61
          */
         setValue( value: number, otherKeys?: number[] ): number;


### PR DESCRIPTION
This change refactors how KeyEvent and Keyset are declared.

In our own, previous type definitions I added a group of constants for keyset groups, e.g. NAVIGATION, VCR etc, which meant we could do something like this:
```
const requiredKeys = KeysetGroup.NAVIGATION | KeysetGroup.BLUE;
const app = oipfObjectFactory.createApplicationManagerObject().getOwnerApplication(document);
app.privateData.keyset.setValue(requiredKeys);
```
These constants are actually read-only properties of the _instance_ of Keyset returned from `app.privateData.keyset`. This would mean the above example would look like this:
```
const app = oipfObjectFactory.createApplicationManagerObject().getOwnerApplication(document);
const keyset = app.privateData.keyset;
const requiredKeys = keyset.NAVIGATION | keyset.BLUE;
keyset.setValue(requiredKeys);
```
My LG and Pana 15 corroborate this reading so I'm reasonably that it's conformant. However, it will be a fundamental change when we integrate this into existing apps and it's that fact that makes me want to be sure it's the correct reading and is correctly implemented on devices.

I have renamed internal objects and interfaces to avoid naming conflicts, but chosen to follow the original author's style of declaring constants and class separately. I'm not sure why it's not a single declared class with `static readonly` properties for the `VK_*` constants, which is what I would have done had I written from scratch.
