### PR TITLE
fix: Removes garbled method in ApplicationManagerObject

### DIFF
--- a/types/objects/ApplicationManagerObject.d.ts
+++ b/types/objects/ApplicationManagerObject.d.ts
@@ -1,25 +1,25 @@
 declare namespace OIPF {
-    
+
     /**
      * 7.2.1 The application/oipfApplicationManager embedded object
     An OITF SHALL support a non-visual embedded object of type “application/oipfApplicationManager”, with
     the following JavaScript API, to enable applications to access the privileged functionality related to application lifecycle
     and management that is provided by the application model defined in this section.
     If one of the methods on the application/oipfApplicationManager is called by a webpage that is not a
-    privileged DAE application, the OITF SHALL throw an error as defined in section 10.1.1. 
+    privileged DAE application, the OITF SHALL throw an error as defined in section 10.1.1.
     */
     export interface ApplicationManagerObject extends HTMLObjectElement {
         type: 'application/oipfApplicationManager';
 
         /**
          * The function that is called when the OITF is running low on available memory for running DAE
-         * applications. The exact criteria when to generate such an event is implementation specific. 
+         * applications. The exact criteria when to generate such an event is implementation specific.
          */
         onLowMemory(): void;
 
         /**
          * The function that is called immediately prior to a `load` event being generated in the affected
-         * application. The specified function is called with one argument `appl`, which provides a reference to the 
+         * application. The specified function is called with one argument `appl`, which provides a reference to the
          * affected application.
          */
         onApplicationLoaded(appl: OIPF.Application): void;
@@ -27,7 +27,7 @@ declare namespace OIPF {
         /**
          * The function that is called immediately prior to an `unload` event being generated in the affected
          * application. The specified function is called with one argument `appl`, which provides a reference to the
-         * affected application. 
+         * affected application.
          */
         onApplicationUnloaded(appl: OIPF.Application): void;
 
@@ -41,29 +41,29 @@ declare namespace OIPF {
          *   section 4.4.6, i.e. multiple applications visible simultaneously with OITF
          *   managing the size, position, visibility of applications
          * - `3` corresponds to the application visualization mode as defined by bullet 3) of
-         *   section 4.4.6, i.e. only a single application visible at any time. 
+         *   section 4.4.6, i.e. only a single application visible at any time.
          */
         getApplicationVisualizationMode(): 1 | 2 | 3;
-        
+
         /**
          * Get the application that the specified document is part of. If the document is not part of
          * an application, or the calling application does not have permission to access that
          * application, this method will return null.
-         * 
+         *
          * @param document The document for which the Application object should be obtained.
          */
         getOwnerApplication( document: Document ): OIPF.Application | null;
 
         /**
          * Get the applications that are children of the specified application.
-         * 
+         *
          * @param application The application whose children should be returned.
          */
         getChildApplications( application: OIPF.Application ): OIPF.ApplicationCollection;
 
         /**
          * Provide a hint to the execution environment that a garbage collection cycle should be
-         * initiated. The OITF is not required to act upon this hint. 
+         * initiated. The OITF is not required to act upon this hint.
          */
         gc(): void;
 
@@ -72,13 +72,12 @@ declare namespace OIPF {
          * an application (e.g. due to an HTTP 404 error, an HTTP timeout, being unable to load the file from a
          * DSM-CC object carousel or due to the file not being either an HTML file). All properties of the
          * `Application` object referred to by appl SHALL have the value `undefined` and calling any methods
-         * on that object SHALL fail. 
+         * on that object SHALL fail.
          */
         onApplicationLoadError( appl: OIPF.Application ): void;
 
         onLowMemory(): void;
         onApplicationLoaded(): void;
         onApplicationUnloaded(): void;
-        onLowMemonApplicationLoadErrorory(): void;
     }
 }


### PR DESCRIPTION
I'm pretty sure `onLowMemonApplicationLoadErrorory` isn't a genuine method, so I've removed it.
It's only been problematic when writing fakes in TypeScript, but one time is too many times, right kids?

It looks like my IDE has joined in by removing trailing whitespaces and adding a newline at the end of the file.
Normally I'd revert that, but this time I'm actually happy about it.