### PR TITLE
fix: TOP-97 - Change exported enum's to be const enum's

### DIFF
--- a/types/objects/ParentalControlManagerObject.d.ts
+++ b/types/objects/ParentalControlManagerObject.d.ts
@@ -2,13 +2,13 @@ declare namespace OIPF {
 
     import BroadcastSupervisor = OpApp.BroadcastSupervisor;
 
-    export enum PINControlStatus {
+    export const enum PINControlStatus {
         CORRECT_PIN = 0,
         INCORRECT_PIN = 1,
         LOCKED = 2,
     }
 
-    export enum VerifyParentalConrolStatus {
+    export const enum VerifyParentalConrolStatus {
         APPROVED = "approved",
         NOT_APPROVED = "notApproved",
     }

--- a/types/opapp/Application.d.ts
+++ b/types/opapp/Application.d.ts
@@ -1,6 +1,6 @@
 declare namespace OpApp {
 
-    export enum OpAppState {
+    export const enum OpAppState {
         FOREGROUND = "foreground",
         BACKGROUND = "background",
         TRANSIENT = "transient",
@@ -8,7 +8,7 @@ declare namespace OpApp {
         OVERLAID_TRANSIENT = "overlaid-transient",
     }
 
-    export enum OpAppUpdateStatus {
+    export const enum OpAppUpdateStatus {
         DISCOVERY_IN_PROGRSS = -3,
         NO_UPDATE_IN_PROGRESS = -2,
         NEW_SOFTWARE_AVAILABLE_FOR_DOWNLOAD = -1,
@@ -16,7 +16,7 @@ declare namespace OpApp {
 
     }
 
-    export enum OpAppUpdateEvent {
+    export const enum OpAppUpdateEvent {
         SOFTWARE_DISCOVERING = "SOFTWARE_DISCOVERING",
         SOFTWARE_DISCOVERY_FAILED = "SOFTWARE_DISCOVERY_FAILED",
         SOFTWARE_CURRENT = "SOFTWARE_CURRENT",
@@ -30,7 +30,7 @@ declare namespace OpApp {
     /**
      * See Table 11 of OpApp Spec
      */
-    export enum OpAppStartupLocation {
+    export const enum OpAppStartupLocation {
         OPAPP_EPG = "opapp-epg",
         OPAPP_PVR = "opapp-pvr",
         OPAPP_SETTINGS = "opapp-setings",
@@ -47,7 +47,7 @@ declare namespace OpApp {
     /**
      * See Table 10 of OpApp Spec
      */
-    export enum OpAppLaunchLocation {
+    export const enum OpAppLaunchLocation {
         INSTALL = "install",
         SETTINGS = "settings",
         SOURCE = "source",

--- a/types/opapp/BroadcastSupervisor.d.ts
+++ b/types/opapp/BroadcastSupervisor.d.ts
@@ -3,7 +3,7 @@ import VideoBroadcastObject = OIPF.VideoBroadcastObject;
 declare namespace OpApp {
 
     /* enums */
-    export enum playState  {
+    export const enum playState  {
         UNREALIZED = 0,
         CONNECTING = 1,
         PRESENTING = 2,
@@ -11,7 +11,7 @@ declare namespace OpApp {
 
     export type playStateError = ChannelChangeErrorState;
 
-    export enum ChannelChangeErrorState {
+    export const enum ChannelChangeErrorState {
         CHANNEL_NOT_SUPPORTED = 0,
         CANNOT_TUNE = 1,
         TUNER_LOCKED = 2,
@@ -29,19 +29,19 @@ declare namespace OpApp {
         UNIDENTIFIED_ERROR = 100,
     }
 
-    export enum AVComponentType {
+    export const enum AVComponentType {
         COMPONENT_TYPE_VIDEO = 0,
         COMPONENT_TYPE_AUDIO = 1,
         COMPONENT_TYPE_SUBTITLE = 2,
     }
 
-    export enum SEEK_REFERENCE_POINT {
+    export const enum SEEK_REFERENCE_POINT {
         POSITION_CURRENT = 0,
         POSITION_START = 1,
         POSITION_END = 2
     }
 
-    export enum BroadcastSupervisorEvents {
+    export const enum BroadcastSupervisorEvents {
         ChannelChangeSucceeded = "ChannelChangeSucceeded",
         ChannelChangeError = "ChannelChangeError",
         PlayStateChange = "PlayStateChange",

--- a/types/opapp/Configuration.d.ts
+++ b/types/opapp/Configuration.d.ts
@@ -1,6 +1,6 @@
 declare namespace OpApp {
 
-    export enum REPLACE_UI_ELEMENTS {
+    export const enum REPLACE_UI_ELEMENTS {
         UI_TVMODE = 0,
         UI_VOLUME = 1,
         UI_PARENTALCONTROL = 2,

--- a/types/opapp/LocalSystem.d.ts
+++ b/types/opapp/LocalSystem.d.ts
@@ -1,5 +1,5 @@
 declare namespace OpApp {
-    export enum PowerState {
+    export const enum PowerState {
         OFF = 0,
         ON = 1,
         PASSIVE_STANDBY = 2,


### PR DESCRIPTION
In order for TypeScript to replace enum references with the actual value at compilation time the enum needs to be exported as a const. See: https://github.com/gibbok/typescript-book#constant-enums