### PR TITLE
OpApp ConfigurationObject Typings & Extension

### DIFF
--- a/types/objects/ConfigurationObject.d.ts
+++ b/types/objects/ConfigurationObject.d.ts
@@ -10,7 +10,7 @@ declare namespace OIPF {
         /**
          * Accesses the configuration object that sets defaults and shows system settings.
          */
-        readonly configuration: OIPF.Configuration | OpApp.Configuration;
+        readonly configuration: OIPF.Configuration;
 
         /**
          * Accesses the object representing the platform hardware.

--- a/types/opapp/objects/ConfigurationObject.d.ts
+++ b/types/opapp/objects/ConfigurationObject.d.ts
@@ -1,0 +1,6 @@
+declare namespace OpApp {
+    // @ts-ignore
+    export interface ConfigurationObject extends OIPF.ConfigurationObject {
+        readonly configuration: OpApp.Configuration;
+    }
+}


### PR DESCRIPTION
Added OpApp ConfigurationObject that extends from the OIPF.ConfigurationObject base.