### PR TITLE
bugFix(TOP-349): correcting BSO properties

### DIFF
--- a/types/opapp/BroadcastSupervisor.d.ts
+++ b/types/opapp/BroadcastSupervisor.d.ts
@@ -72,14 +72,14 @@ declare namespace OpApp {
         /* Properties */
         readonly playState: playState;
         readonly playStateError: playStateError;
-        readonly playSpeed: Pick<OpApp.VideoBroadcastObject, "playSpeed">;
-        readonly playPosition: Pick<OpApp.VideoBroadcastObject, "playPosition">;
-        readonly playbackOffset: Pick<OpApp.VideoBroadcastObject, "playbackOffset">;
-        readonly maxOffset: Pick<OpApp.VideoBroadcastObject, "maxOffset">;
-        readonly timeShiftMode: Pick<OpApp.VideoBroadcastObject, "timeShiftMode">;
-        readonly currentTimeShiftMode: Pick<OpApp.VideoBroadcastObject, "currentTimeShiftMode">;
-        readonly programmes: Pick<OpApp.VideoBroadcastObject, "programmes">;
-        readonly currentChannel: Pick<OpApp.VideoBroadcastObject, "currentChannel">;
+        readonly playSpeed: OpApp.VideoBroadcastObject["playSpeed"];
+        readonly playPosition: OpApp.VideoBroadcastObject["playPosition"];
+        readonly playbackOffset: OpApp.VideoBroadcastObject["playbackOffset"];
+        readonly maxOffset: OpApp.VideoBroadcastObject["maxOffset"];
+        readonly timeShiftMode: OpApp.VideoBroadcastObject["timeShiftMode"];
+        readonly currentTimeShiftMode: OpApp.VideoBroadcastObject["currentTimeShiftMode"];
+        readonly programmes: OpApp.VideoBroadcastObject["programmes"];
+        readonly currentChannel: OpApp.VideoBroadcastObject["currentChannel"]; 
 
         /* Events */
         onChannelChangeError(channel: OIPF.Channel, errorState: ChannelChangeErrorState): void;


### PR DESCRIPTION
By employing direct object indexing instead of the Pick utility, we enhance type accuracy, which resolves the issue with object properties like `broadcastSupObj.currentChannel.currentChannel.majorChannel`. As a result, we can eliminate the 'any' type assertion in the following code pattern:

```typescript
(broadcastObject?.bso as any)?.currentChannel as OIPF.Channel;
```

and use the object directly:

```typescript
(broadcastObject?.bso)?.currentChannel as OIPF.Channel;
```