### PR TITLE
fix (TOP-1125): Adds ref tags to BroadcastSupervisor definition.

### DIFF
--- a/types/opapp/BroadcastSupervisor.d.ts
+++ b/types/opapp/BroadcastSupervisor.d.ts
@@ -1,3 +1,6 @@
+/// <reference path="../AVComponent.d.ts" />
+/// <reference path="../AVComponentCollection.d.ts" />
+
 import VideoBroadcastObject = OIPF.VideoBroadcastObject;
 
 declare namespace OpApp {


### PR DESCRIPTION
Causing issues in dependent projects when this projects source is not included in a typescript project's `include` block.
That shouldn't be necessary, I think.